### PR TITLE
Add libdispatch build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && \
       cmake \
       git \
       icu-devtools \
+      autoconf \
+      libtool \
       libbsd-dev \
       libedit-dev \
       libicu-dev \
@@ -18,6 +20,8 @@ RUN apt-get update && \
       pkg-config \
       swig \
       uuid-dev \
+      libkqueue-dev \
+      libblocksruntime-dev \
       && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 100 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100 && \


### PR DESCRIPTION
We are finally reaching the point where `swift-corelibs-libdispatch` can be built for Linux and be generally functional. Doing so requires some additional package dependencies which I'm adding here.
